### PR TITLE
Modify use videoStabilizationMode in RCTCamera

### DIFF
--- a/ios/RCT/RCTCameraManager.m
+++ b/ios/RCT/RCTCameraManager.m
@@ -888,12 +888,14 @@ RCT_EXPORT_METHOD(setZoom:(CGFloat)zoomFactor) {
     }
 
     AVCaptureConnection *connection = [self.movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
+
+    int32_t videoStabilizationMode = [[options valueForKey:@"videoStabilizationMode"] intValue];
     
-    if (self.videoStabilizationMode != 0) {
+    if (videoStabilizationMode != 0) {
         if (connection.isVideoStabilizationSupported == NO) {
             RCTLogWarn(@"%s: Video Stabilization is not supported on this device.", __func__);
         } else {
-            [connection setPreferredVideoStabilizationMode:self.videoStabilizationMode];
+            [connection setPreferredVideoStabilizationMode:videoStabilizationMode];
         }
     }
 

--- a/src/Camera.js
+++ b/src/Camera.js
@@ -130,7 +130,6 @@ export default class Camera extends Component {
     permissionDialogMessage: PropTypes.string,
     notAuthorizedView: PropTypes.element,
     pendingAuthorizationView: PropTypes.element,
-    videoStabilizationMode: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   };
 
   static defaultProps = {
@@ -163,7 +162,6 @@ export default class Camera extends Component {
         <ActivityIndicator size="small" />
       </View>
     ),
-    videoStabilizationMode: 0,
   };
 
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;
@@ -316,6 +314,7 @@ export default class Camera extends Component {
       fixOrientation: props.fixOrientation,
       cropToPreview: props.cropToPreview,
       ...options,
+      videoStabilizationMode: options.videoStabilizationMode || 0,
     };
 
     if (options.mode === Camera.constants.CaptureMode.video) {


### PR DESCRIPTION
Modify the use videoStabilizationMode in RCTCamera
Example
```
    this.camera
      .capture({
        totalSeconds: this.props.maxDuration,
        audio: true,
        videoStabilizationMode: Camera.constants.VideoStabilization.auto,
      })
```